### PR TITLE
Simplified example proofs for single messages using SMT patterns

### DIFF
--- a/src/request_response/DY.Example.RequestResponse.Protocol.Stateful.Proof.fst
+++ b/src/request_response/DY.Example.RequestResponse.Protocol.Stateful.Proof.fst
@@ -14,7 +14,7 @@ open DY.Example.RequestResponse.Protocol.Stateful
 
 #push-options "--ifuel 3 --z3rlimit 20"
 let state_predicates_protocol: local_state_predicate protocol_state = {
-  pred = (fun tr prin sess_id st -> 
+  pred = (fun tr prin sess_id st ->
     match st with
     | ClientSendRequest {server; cmeta_data; nonce} -> (
       let client = prin in
@@ -119,7 +119,7 @@ let protocol_invariants_protocol_communication_layer_reqres_event_invariant = al
 
 (*** Proofs ***)
 
-#push-options "--z3rlimit 10"
+#push-options "--ifuel 3"
 val client_send_request_proof:
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -134,11 +134,11 @@ val client_send_request_proof:
   ))
   [SMTPat (trace_invariant tr); SMTPat (client_send_request comm_keys_ids client server tr)]
 let client_send_request_proof tr comm_keys_ids client server =
-  assert(apply_com_layer_lemmas comm_layer_event_preds);
+  assert(apply_reqres_comm_layer_lemmas comm_layer_event_preds);
   ()
 #pop-options
 
-#push-options "--ifuel 1 --z3rlimit 85"
+#push-options "--ifuel 3 --z3rlimit 75"
 val server_receive_request_send_response_proof:
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -154,29 +154,8 @@ val server_receive_request_send_response_proof:
   ))
   [SMTPat (trace_invariant tr); SMTPat (server_receive_request_send_response comm_keys_ids server msg_id tr)]
 let server_receive_request_send_response_proof tr comm_keys_ids server msg_id =
-  assert(apply_com_layer_lemmas comm_layer_event_preds);
-  let (_, tr_out) = server_receive_request_send_response comm_keys_ids server msg_id tr in
-  match receive_request comm_keys_ids server msg_id tr with
-  | (None, tr) -> assert(tr == tr_out)
-  | (Some (Request req, cmeta_data), tr) -> (
-    let send_event client = CommClientSendRequest client server (serialize message_t (Request req)) cmeta_data.key in
-    assert(trace_invariant tr);
-    eliminate (exists client. event_triggered tr client (send_event client)) \/
-              is_publishable tr cmeta_data.key
-    returns is_knowable_by (comm_label req.client server) tr req.nonce
-    with _. eliminate exists client. event_triggered tr client (send_event client)
-      returns _
-      with _. (
-        let i = find_event_triggered_at_timestamp tr client (send_event client) in
-        // Triggers event_triggered_at_implies_pred
-        assert(event_triggered_at tr i client (send_event client));
-        // From protocol event predicate
-        assert(is_knowable_by (comm_label req.client server) tr req.nonce)
-      )
-    and _. assert(is_well_formed message_t (is_publishable tr) (Request req));
-    ()
-  )
-  | (Some _, tr) -> assert(tr == tr_out)
+  assert(apply_reqres_comm_layer_lemmas comm_layer_event_preds);
+  ()
 #pop-options
 
 #push-options "--ifuel 4 --z3rlimit 40"
@@ -194,6 +173,6 @@ val client_receive_response_proof:
   ))
   [SMTPat (trace_invariant tr); SMTPat (client_receive_response client sid msg_id tr)]
 let client_receive_response_proof tr client sid msg_id =
-  assert(apply_com_layer_lemmas comm_layer_event_preds);
+  assert(apply_reqres_comm_layer_lemmas comm_layer_event_preds);
   ()
 #pop-options

--- a/src/single_auth_message/DY.Example.SingleAuthMessage.Protocol.Stateful.fst
+++ b/src/single_auth_message/DY.Example.SingleAuthMessage.Protocol.Stateful.fst
@@ -52,12 +52,9 @@ let prepare_message sender receiver =
 val send_message: communication_keys_sess_ids -> principal -> principal -> state_id -> traceful (option timestamp)
 let send_message comm_keys_ids sender receiver state_id =
   let*? st:single_message_state = get_state sender state_id in
-  match st with
-  | SenderState msg -> (
-    let*? msg_id = send_authenticated #single_message comm_keys_ids sender receiver msg in
-    return (Some msg_id)
-  )
-  | _ -> return None
+  guard_tr (SenderState? st);*?
+  let SenderState msg = st in
+  send_authenticated #single_message comm_keys_ids sender receiver msg
 
 val receive_message: communication_keys_sess_ids -> principal -> timestamp -> traceful (option state_id)
 let receive_message comm_keys_ids receiver msg_id =

--- a/src/single_conf_and_auth_message/DY.Example.SingleConfAuthMessage.Protocol.Stateful.fst
+++ b/src/single_conf_and_auth_message/DY.Example.SingleConfAuthMessage.Protocol.Stateful.fst
@@ -52,12 +52,9 @@ let prepare_message sender receiver =
 val send_message: communication_keys_sess_ids -> principal -> principal -> state_id -> traceful (option timestamp)
 let send_message comm_keys_ids sender receiver state_id =
   let*? st:single_message_state = get_state sender state_id in
-  match st with
-  | SenderState receiver msg -> (
-    let*? msg_id = send_confidential_authenticated comm_keys_ids sender receiver msg in
-    return (Some msg_id)
-  )
-  | _ -> return None
+  guard_tr (SenderState? st);*?
+  let SenderState receiver msg = st in
+  send_confidential_authenticated comm_keys_ids sender receiver msg
 
 val receive_message: communication_keys_sess_ids -> principal -> timestamp -> traceful (option state_id)
 let receive_message comm_keys_ids receiver msg_id =

--- a/src/single_conf_message/DY.Example.SingleConfMessage.Protocol.Stateful.fst
+++ b/src/single_conf_message/DY.Example.SingleConfMessage.Protocol.Stateful.fst
@@ -51,13 +51,10 @@ let prepare_message sender receiver =
 val send_message: communication_keys_sess_ids -> principal -> principal -> state_id -> traceful (option timestamp)
 let send_message comm_keys_ids sender receiver state_id =
   let*? st:single_message_state = get_state sender state_id in
-  match st with
-  | SenderState receiver msg -> (
-    trigger_event sender (SenderSendMsg sender receiver msg);*
-    let*? msg_id = send_confidential comm_keys_ids sender receiver msg in
-    return (Some msg_id)
-  )
-  | _ -> return None
+  guard_tr (SenderState? st);*?
+  let SenderState receiver msg = st in
+  trigger_event sender (SenderSendMsg sender receiver msg);*
+  send_confidential comm_keys_ids sender receiver msg
 
 val receive_message: communication_keys_sess_ids -> principal -> timestamp -> traceful (option state_id)
 let receive_message comm_keys_ids receiver msg_id =


### PR DESCRIPTION
As in the title.

I think this probably doesn't fully generalize to more complex predicates, but at least for the simple single-message examples, all that was needed was an ifuel of 3 in the send message case (to handle unpacking the state), and, somewhat surprisingly, no ifuel in the receive case. All proofs go through automatically and quickly with the SMTPats from https://github.com/REPROSEC/dolev-yao-star-extrinsic/pull/102 (probably with speed also helped by the opaqueness of the functions being used).

This should go in parallel with https://github.com/REPROSEC/dolev-yao-star-extrinsic/pull/102 --- for instance, the request/response predicates still need to be handled in that PR, and we will need corresponding changes here as well.